### PR TITLE
Throw error when loading GRIB files on Windows

### DIFF
--- a/src/GeoIO.jl
+++ b/src/GeoIO.jl
@@ -22,8 +22,10 @@ import VTKBase.VTKCellTypes
 
 # CDM formats
 import CommonDataModel as CDM
-import GRIBDatasets
 import NCDatasets
+@static if !Sys.iswindows()
+  import GRIBDatasets
+end
 
 # mesh formats
 import PlyIO

--- a/src/GeoIO.jl
+++ b/src/GeoIO.jl
@@ -22,10 +22,8 @@ import VTKBase.VTKCellTypes
 
 # CDM formats
 import CommonDataModel as CDM
+import GRIBDatasets
 import NCDatasets
-@static if !Sys.iswindows()
-  import GRIBDatasets
-end
 
 # mesh formats
 import PlyIO

--- a/src/extra/cdm.jl
+++ b/src/extra/cdm.jl
@@ -55,7 +55,7 @@ end
 
 function _gribdataset(fname)
   @static if Sys.iswindows()
-    error("loading GRIB files is not supported on Windows")
+    error("loading GRIB files is currently not supported on Windows")
   else
     GRIBDatasets.GRIBDataset(fname)
   end

--- a/src/extra/cdm.jl
+++ b/src/extra/cdm.jl
@@ -4,9 +4,9 @@
 
 function cdmread(fname; x=nothing, y=nothing, z=nothing, t=nothing, lazy=false)
   ds = if endswith(fname, ".grib")
-    GRIBDatasets.GRIBDataset(fname)
+    _gribdataset(fname)
   elseif endswith(fname, ".nc")
-    NCDatasets.NCDataset(fname, "r")
+    _ncdataset(fname)
   else
     error("unsupported Common Data Model file format")
   end
@@ -52,6 +52,16 @@ function cdmread(fname; x=nothing, y=nothing, z=nothing, t=nothing, lazy=false)
 
   GeoTable(grid; vtable)
 end
+
+function _gribdataset(fname)
+  @static if Sys.iswindows()
+    error("loading GRIB files is not supported on Windows")
+  else
+    GRIBDatasets.GRIBDataset(fname)
+  end
+end
+
+_ncdataset(fname) = NCDatasets.NCDataset(fname, "r")
 
 const XNAMES = ["x", "X", "lon", "longitude"]
 const YNAMES = ["y", "Y", "lat", "latitude"]

--- a/src/extra/cdm.jl
+++ b/src/extra/cdm.jl
@@ -54,7 +54,7 @@ function cdmread(fname; x=nothing, y=nothing, z=nothing, t=nothing, lazy=false)
 end
 
 function _gribdataset(fname)
-  @static if Sys.iswindows()
+  if Sys.iswindows()
     error("loading GRIB files is currently not supported on Windows")
   else
     GRIBDatasets.GRIBDataset(fname)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -233,10 +233,14 @@ end
       # the "regular_gg_ml.grib" file is a test file from the GRIBDatasets.jl package
       # link: https://github.com/JuliaGeo/GRIBDatasets.jl/blob/main/test/sample-data/regular_gg_ml.grib
       file = joinpath(datadir, "regular_gg_ml.grib")
-      table = GeoIO.load(file)
-      @test table.geometry isa RectilinearGrid
-      @test isnothing(values(table))
-      @test isnothing(values(table, 0))
+      if Sys.iswindows()
+        @test_throws ErrorException GeoIO.load(file)
+      else
+        table = GeoIO.load(file)
+        @test table.geometry isa RectilinearGrid
+        @test isnothing(values(table))
+        @test isnothing(values(table, 0))
+      end
     end
 
     @testset "Shapefile" begin


### PR DESCRIPTION
Motivation: the GRIB.jl package, the main dependency of GRIBDatasets.jl, in its latest stable version, v0.3.0, does not work on Windows.

This PR fixes this issue by throwing an error when reading GRUB files if the user uses Windows.