### PR TITLE
Create cartesiangrid using crs information

### DIFF
--- a/src/extra/geotiff.jl
+++ b/src/extra/geotiff.jl
@@ -8,7 +8,7 @@ function geotiffread(fname; kwargs...)
   gt = AG.getgeotransform(dataset)
   ps = [AG.applygeotransform(gt, Float64(x), Float64(y)) for x in (0, dims[1]) for y in (0, dims[2])]
   box = boundingbox([Point(p...) for p in ps])
-  domain = CartesianGrid(minimum(box), maximum(box), dims = dims)
+  domain = CartesianGrid(minimum(box), maximum(box); dims)
   pairs = map(1:AG.nraster(dataset)) do i
     name = Symbol(:BAND, i)
     column = AG.read(dataset, i) |> transpose |> rotr90

--- a/src/extra/geotiff.jl
+++ b/src/extra/geotiff.jl
@@ -5,7 +5,10 @@
 function geotiffread(fname; kwargs...)
   dataset = AG.read(fname; kwargs...)
   dims = (Int(AG.width(dataset)), Int(AG.height(dataset)))
-  domain = CartesianGrid(dims)
+  gt = AG.getgeotransform(dataset)
+  ps = [AG.applygeotransform(gt, Float64(x), Float64(y)) for x in (0, dims[1]) for y in (0, dims[2])]
+  box = boundingbox([Point(p...) for p in ps])
+  domain = CartesianGrid(minimum(box), maximum(box), dims = dims)
   pairs = map(1:AG.nraster(dataset)) do i
     name = Symbol(:BAND, i)
     column = AG.read(dataset, i) |> transpose |> rotr90


### PR DESCRIPTION
When reading `.tif` files, the associated domain should be created using the coordinates information. This PR identifies the lower and upper points to create the `CartesianGrid` because `.tif` files do not always have positive spacing meaning that the origin or reference point can be any of the 4 corners. Ideally, we should only detect the `origin` and the `spacing` of the `.tif` file to create the `CartesianGrid`; however, our current CartesianGrid implementation does not accept negative spacing.