### PR TITLE
Workaround for saving CRS in GeoParquet files

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -64,7 +64,7 @@ crstype(crs::GFT.EPSG, _) = CoordRefSystems.get(EPSG{GFT.val(crs)})
 crstype(crs::GFT.WellKnownText, _) = CoordRefSystems.get(GFT.val(crs))
 crstype(crs::GFT.WellKnownText2, _) = CoordRefSystems.get(GFT.val(crs))
 crstype(crs::GFT.ESRIWellKnownText, _) = CoordRefSystems.get(GFT.val(crs))
-crstype(crs::GFT.ProjJSON, _) = CoordRefSystems.get(projjsoncrs(GFT.val(crs)))
+crstype(crs::GFT.ProjJSON, _) = CoordRefSystems.get(projjsoncode(GFT.val(crs)))
 crstype(_, geom) = Cartesian{NoDatum,GI.is3d(geom) ? 3 : 2}
 
 function topoint(geom, CRS)

--- a/src/save.jl
+++ b/src/save.jl
@@ -164,7 +164,8 @@ function save(fname, geotable; kwargs...)
     end
     GJS.write(fname, geotable |> proj; kwargs...)
   elseif endswith(fname, ".parquet")
-    GPQ.write(fname, geotable, (:geometry,); kwargs...)
+    CRS = crs(domain(geotable))
+    GPQ.write(fname, geotable, (:geometry,), projjson(CRS); kwargs...)
   else # fallback to GDAL
     agwrite(fname, geotable; kwargs...)
   end

--- a/test/io/geoparquet.jl
+++ b/test/io/geoparquet.jl
@@ -69,5 +69,21 @@
     gtb2 = GeoIO.load(file2)
     @test gtb1 == gtb2
     @test values(gtb1, 0) == values(gtb2, 0)
+
+    file1 = joinpath(datadir, "points_latlon.parquet")
+    file2 = joinpath(savedir, "points_latlon.parquet")
+    gtb1 = GeoIO.load(file1)
+    GeoIO.save(file2, gtb1)
+    gtb2 = GeoIO.load(file2)
+    @test gtb1 == gtb2
+    @test values(gtb1, 0) == values(gtb2, 0)
+
+    file1 = joinpath(datadir, "points_projected.parquet")
+    file2 = joinpath(savedir, "points_projected.parquet")
+    gtb1 = GeoIO.load(file1)
+    GeoIO.save(file2, gtb1)
+    gtb2 = GeoIO.load(file2)
+    @test gtb1 == gtb2
+    @test values(gtb1, 0) == values(gtb2, 0)
   end
 end


### PR DESCRIPTION
This is necessary because the GeoParquet package does not use the GeoInterface to get the CRS from the Feature Collection.