### PR TITLE
add GeoIO.loadvalues function

### DIFF
--- a/src/GeoIO.jl
+++ b/src/GeoIO.jl
@@ -134,6 +134,7 @@ include("extra/img.jl")
 include("extra/cdm.jl")
 include("extra/gdal.jl")
 include("extra/geotiff.jl")
+include("extra/gis.jl")
 
 # user functions
 include("load.jl")

--- a/src/GeoIO.jl
+++ b/src/GeoIO.jl
@@ -112,7 +112,11 @@ function formats(io::IO=stdout; sortby::Symbol=:extension)
   pretty_table(io, sorted, alignment=:c, crop=:none, show_subheader=false)
 end
 
-include("utils.jl")
+# generic utilities
+include("utils/basic.jl")
+
+# GIS-specific utilities
+include("utils/gis.jl")
 
 # conversions
 include("conversion.jl")

--- a/src/extra/gis.jl
+++ b/src/extra/gis.jl
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+function gisread(fname; layer, numbertype, repair, kwargs...)
+  # extract Tables.jl table from GIS format
+  table = gistable(fname; layer, numbertype, kwargs...)
+
+  # convert Tables.jl table to GeoTable
+  geotable = asgeotable(table)
+
+  # repair pipeline
+  pipeline = if repair
+    Repair(11) → Repair(12)
+  else
+    Identity()
+  end
+
+  # perform repairs
+  geotable |> pipeline
+end

--- a/src/load.jl
+++ b/src/load.jl
@@ -209,7 +209,7 @@ function loadvalues(fname; emptyonly=false, kwargs...)
   table = if endswith(fname, ".shp")
     SHP.Table(fname; kwargs...)
   elseif endswith(fname, ".geojson")
-    GJS.read(fname; numbertype, kwargs...)
+    GJS.read(fname; numbertype=Float64, kwargs...) #numbertype not relevant here
   elseif endswith(fname, ".parquet")
     GPQ.read(fname; kwargs...)
   else # fallback to GDAL

--- a/src/load.jl
+++ b/src/load.jl
@@ -24,9 +24,9 @@ are forwarded to the backend packages.
 Please use the [`formats`](@ref) function to list
 all supported file formats.
 
-GIS formats that support missing geometries are considered
-bad practice. In that case, we provide the auxiliary function
-[`loadvalues`](@ref) with similar options.
+GIS formats with missing geometries are considered bad practice.
+In this case, we provide the auxiliary function [`loadvalues`](@ref)
+with similar options.
 
 ## Options
 
@@ -78,6 +78,7 @@ bad practice. In that case, we provide the auxiliary function
 ```julia
 # load coordinates of geojson file as Float64 (default)
 GeoIO.load("file.geojson")
+
 # load coordinates of geojson file as Float32
 GeoIO.load("file.geojson", numbertype=Float32)
 ```

--- a/src/load.jl
+++ b/src/load.jl
@@ -160,12 +160,13 @@ end
 """
     GeoIO.loadvalues(fname; rows=:all, kwargs...)
 
-Load `values` of geospatial table from file `fname` stored in any GIS format.
+Load `values` of geospatial table from file `fname` stored in any GIS format,
+skipping the steps to build the `domain` (i.e., geometry column).
 
-The function is particularly useful when geometries are missing, which we consider
-bad practice. In this case, the option `rows=:invalid` can be used to retrieve the
-values of the rows that were dropped by [`load`](@ref). All other options documented
-therein for GIS formats are supported.
+The function is particularly useful when geometries are missing. In this case,
+the option `rows=:invalid` can be used to retrieve the values of the rows that
+were dropped by [`load`](@ref). All other options documented therein for GIS
+formats are supported.
 
 ## Examples
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -191,7 +191,7 @@ function loadvalues(fname; rows=:all, kwargs...)
   isempty(vars) && return nothing 
 
   # build values table
-  values = (; (v => Tables.getcolumn(cols, v) for v in vars)...)
+  values = namedtuple(vars, cols)
 
   # filter rows if necessary
   if rows === :invalid

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,7 +20,8 @@ function asgeotable(table)
   # subset for missing geoms
   miss = findall(g -> ismissing(g) || isnothing(g), geoms)
   if !isempty(miss)
-    @warn "$(length(miss)) rows dropped from GeoTable because of empty or missing geometries."
+    @warn "$(length(miss)) rows dropped from GeoTable because of empty or missing geometries. \
+    You can use GeoIO.loadvalues(; emptyonly=true) to inspect data for these geometries."
   end
   valid = setdiff(1:length(geoms), miss)
   domain = geom2meshes.(geoms[valid], Ref(crs))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,8 +20,8 @@ function asgeotable(table)
   # subset for missing geoms
   miss = findall(g -> ismissing(g) || isnothing(g), geoms)
   if !isempty(miss)
-    @warn """$(length(miss)) rows dropped from GeoTable because of empty or missing geometries. 
-    Please use GeoIO.loadvalues(; emptyonly=true) to inspect data for these geometries.
+    @warn """$(length(miss)) rows dropped from GeoTable because of missing geometries. 
+    Please use GeoIO.loadvalues(; rows=:invalid) to load values without geometries.
     """
   end
   valid = setdiff(1:length(geoms), miss)
@@ -102,7 +102,6 @@ function projjson(CRS)
   end
 end
 
-# load GIS format data
 function gistable(fname; layer=0, numbertype=Float64, kwargs...)
   if endswith(fname, ".shp")
     return SHP.Table(fname; kwargs...)

--- a/src/utils/basic.jl
+++ b/src/utils/basic.jl
@@ -24,3 +24,10 @@ function uniquenames(names, newnames)
     uniquename(names, name)
   end
 end
+
+# construct named tuple with static number of variables
+function namedtuple(vars, cols)
+  tvars = Tuple(vars)
+  tvals = ntuple(i -> Tables.getcolumn(cols, tvars[i]), length(tvars))
+  NamedTuple{tvars}(tvals)
+end

--- a/src/utils/basic.jl
+++ b/src/utils/basic.jl
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------
+# Licensed under the MIT License. See LICENSE in the project root.
+# ------------------------------------------------------------------
+
+# type aliases
+const Met{T} = Quantity{T,u"𝐋",typeof(u"m")}
+const Deg{T} = Quantity{T,NoDims,typeof(u"°")}
+
+# default length unit if not set
+lengthunit(u) = isnothing(u) ? m : u
+
+# append '_' to `name` until it is unique compared to `names`
+function uniquename(names, name)
+  uname = name
+  while uname ∈ names
+    uname = Symbol(uname, :_)
+  end
+  uname
+end
+
+# make `newnames` unique compared to `names`
+function uniquenames(names, newnames)
+  map(newnames) do name
+    uniquename(names, name)
+  end
+end

--- a/src/utils/gis.jl
+++ b/src/utils/gis.jl
@@ -28,9 +28,7 @@ function asgeotable(table)
   # subset for missing geoms
   miss = findall(g -> ismissing(g) || isnothing(g), geoms)
   if !isempty(miss)
-    @warn """$(length(miss)) rows dropped from GeoTable because of missing geometries. 
-    Please use GeoIO.loadvalues(; rows=:invalid) to load values without geometries.
-    """
+    @warn "Dropping $(length(miss)) rows with missing geometries. Please use `GeoIO.loadvalues(fname; rows=:invalid)` to load their values."
   end
   valid = setdiff(1:length(geoms), miss)
   domain = geom2meshes.(geoms[valid], Ref(crs))

--- a/src/utils/gis.jl
+++ b/src/utils/gis.jl
@@ -23,7 +23,7 @@ function asgeotable(table)
   names = Tables.columnnames(cols)
   gcol = geomcolumn(names)
   vars = setdiff(names, [gcol])
-  etable = isempty(vars) ? nothing : (; (v => Tables.getcolumn(cols, v) for v in vars)...)
+  etable = isempty(vars) ? nothing : namedtuple(vars, cols)
   geoms = Tables.getcolumn(cols, gcol)
   # subset for missing geoms
   miss = findall(g -> ismissing(g) || isnothing(g), geoms)

--- a/test/io/shapefile.jl
+++ b/test/io/shapefile.jl
@@ -64,16 +64,14 @@
     @test GeoIO.load(joinpath(datadir, "lines.shp")) isa AbstractGeoTable
 
     # https://github.com/JuliaEarth/GeoIO.jl/issues/158
-    gtb = @test_warn r"1 rows dropped" GeoIO.load(joinpath(datadir, "issue158.shp"))
+    fname = joinpath(datadir, "issue158.shp")
+    gtb = @test_warn r"1 rows dropped" GeoIO.load(fname)
     @test gtb isa AbstractGeoTable
-    # values only loading
-    gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"))
-    @test Tables.getcolumn(gtb, :SA22023__2) == ["Putaruru Rural", "Oceanic Kermadec Islands"]
-    # values only, empty only loading
-    gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"); rows=:invalid)
-    @test Tables.getcolumn(gtb, :SA22023__2) == ["Oceanic Kermadec Islands"]
-    # argument error in loadvalues() function
-    @test_throws ArgumentError gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"); rows=:incorrect_argument)
+    tb = GeoIO.loadvalues(fname)
+    @test Tables.getcolumn(tb, :SA22023__2) == ["Putaruru Rural", "Oceanic Kermadec Islands"]
+    tb = GeoIO.loadvalues(fname; rows=:invalid)
+    @test Tables.getcolumn(tb, :SA22023__2) == ["Oceanic Kermadec Islands"]
+    @test_throws ArgumentError GeoIO.loadvalues(fname, rows=:incorrect)
   end
 
   @testset "save" begin

--- a/test/io/shapefile.jl
+++ b/test/io/shapefile.jl
@@ -66,10 +66,10 @@
     # https://github.com/JuliaEarth/GeoIO.jl/issues/158
     gtb = @test_warn r"1 rows dropped" GeoIO.load(joinpath(datadir, "issue158.shp"))
     @test gtb isa AbstractGeoTable
-    # Values only loading
+    # values only loading
     gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"))
     @test Tables.getcolumn(gtb, :SA22023__2) == ["Putaruru Rural", "Oceanic Kermadec Islands"]
-    # Values only, empty only loading
+    # values only, empty only loading
     gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"); emptyonly=true)
     @test Tables.getcolumn(gtb, :SA22023__2) == ["Oceanic Kermadec Islands"]
   end

--- a/test/io/shapefile.jl
+++ b/test/io/shapefile.jl
@@ -66,6 +66,12 @@
     # https://github.com/JuliaEarth/GeoIO.jl/issues/158
     gtb = @test_warn r"1 rows dropped" GeoIO.load(joinpath(datadir, "issue158.shp"))
     @test gtb isa AbstractGeoTable
+    # Values only loading
+    gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"))
+    @test Tables.getcolumn(gtb, :SA22023__2) == ["Putaruru Rural", "Oceanic Kermadec Islands"]
+    # Values only, empty only loading
+    gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"); emptyonly=true)
+    @test Tables.getcolumn(gtb, :SA22023__2) == ["Oceanic Kermadec Islands"]
   end
 
   @testset "save" begin

--- a/test/io/shapefile.jl
+++ b/test/io/shapefile.jl
@@ -65,7 +65,7 @@
 
     # https://github.com/JuliaEarth/GeoIO.jl/issues/158
     fname = joinpath(datadir, "issue158.shp")
-    gtb = @test_warn r"1 rows dropped" GeoIO.load(fname)
+    gtb = @test_warn r"Dropping 1 rows" GeoIO.load(fname)
     @test gtb isa AbstractGeoTable
     tb = GeoIO.loadvalues(fname)
     @test Tables.getcolumn(tb, :SA22023__2) == ["Putaruru Rural", "Oceanic Kermadec Islands"]

--- a/test/io/shapefile.jl
+++ b/test/io/shapefile.jl
@@ -70,8 +70,10 @@
     gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"))
     @test Tables.getcolumn(gtb, :SA22023__2) == ["Putaruru Rural", "Oceanic Kermadec Islands"]
     # values only, empty only loading
-    gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"); emptyonly=true)
+    gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"); rows=:invalid)
     @test Tables.getcolumn(gtb, :SA22023__2) == ["Oceanic Kermadec Islands"]
+    # argument error in loadvalues() function
+    @test_throws ArgumentError gtb = GeoIO.loadvalues(joinpath(datadir, "issue158.shp"); rows=:incorrect_argument)
   end
 
   @testset "save" begin


### PR DESCRIPTION
A PR for the suggestion raised in #158 to add a GeoIO.loadvalues() function, allowing loading non-geographic data. It comes with a `loadempty=false` option to allow loading only rows where geometries are empty. If no non-geographic data is found, we return `nothing`.

I also modified the warning message in `asgeotable()` appropriately.

The return object is just the basic Tables.jl NTuple version of the data as a table - I thought this was simple enough since I couldn't see how to make `georef()` accept data without geometries, and most users will just call `DataFrame()` on it I expect. 

I'm not experienced writing documentation, so it would be good if the reviewer could please take a quick look?